### PR TITLE
Titles could be better

### DIFF
--- a/scrum/templates/scrum/base.html
+++ b/scrum/templates/scrum/base.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ block.super }} / {{ project.name|default:"Projects" }}{% endblock %}
+{% block title %}{{ project.name|default:"Projects" }} / {{ block.super }}{% endblock %}
 
 {% block content %}
   <div class="row">

--- a/scrum/templates/scrum/sprint.html
+++ b/scrum/templates/scrum/sprint.html
@@ -1,6 +1,6 @@
 {% extends "scrum/base.html" %}
 
-{% block title %}{{ block.super }} / {{ sprint.name }}{% endblock %}
+{% block title %}{{ sprint.name }} / {{ block.super }}{% endblock %}
 
 {% block content %}
   {% if bzerror %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ block.super }} / 404{% endblock %}
+{% block title %}404 / {{ block.super }}{% endblock %}
 
 {% block content %}
   <div class="hero-unit">

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ block.super }} / 500{% endblock %}
+{% block title %}500 / {{ block.super }}{% endblock %}
 
 {% block content %}
   <div class="hero-unit">


### PR DESCRIPTION
The current page title is "ScrumBugs / Project / Sprint", which means mutliple ScrumBugs tabs are indistinguishable. Something like "Project / Sprint / ScrumBugs" would be a lot easier to parse for humans.
