### PR TITLE
Update issue tracker url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Code:
     https://github.com/pmclanahan/scrumbugz
 
 Issues:
-    https://github.com/pmclanahan/scrumbugz/issues
+    https://github.com/mozilla/scrumbugz/issues
 
 CI:
     .. image:: https://secure.travis-ci.org/pmclanahan/scrumbugz.png

--- a/docs/join.rst
+++ b/docs/join.rst
@@ -13,7 +13,7 @@ Code:
     https://github.com/pmclanahan/scrumbugz
 
 Issues:
-    https://github.com/pmclanahan/scrumbugz/issues
+    https://github.com/mozilla/scrumbugz/issues
 
 Documentation:
     http://scrumbugz.readthedocs.org/

--- a/templates/base.html
+++ b/templates/base.html
@@ -73,7 +73,7 @@
           </a>
         </p>
 
-        <p>Problem? Suggestion? <a href="https://github.com/pmclanahan/scrumbugz/issues">File an issue</a>.</p>
+        <p>Problem? Suggestion? <a href="https://github.com/mozilla/scrumbugz/issues">File an issue</a>.</p>
       </footer>
 
     </div> <!-- /container -->


### PR DESCRIPTION
The github issues tracker has moved to the mozilla account on github.
Update the docs and templates.
