### PR TITLE
Round up fractional ideal points to avoid fractional point tooltips

### DIFF
--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -6,6 +6,7 @@
     };
 
     window.StatsChart = function(selector, stats_data, ticks) {
+        var DAY = 24 * 60 * 60 * 1000;
         var self = this;
         self.$element = $(selector);
         self.$element.data('flot', self);
@@ -73,8 +74,8 @@
             do {
                 // when we don't set yaxis, the rectangle automatically
                 // extends to infinity upwards and downwards
-                markings.push({ xaxis: { from: i, to: i + 2 * 24 * 60 * 60 * 1000 } });
-                i += 7 * 24 * 60 * 60 * 1000;
+                markings.push({ xaxis: { from: i, to: i + 2 * DAY } });
+                i += 7 * DAY;
             } while (i < axes.xaxis.max);
 
             return markings;


### PR DESCRIPTION
This PR fixes #104 and includes some small code refactoring.

I experimented with a number of options for fixing the fractional point tooltips. I tried displaying tooltips like "2.333" as "2+" or "~3", but the tooltips looked funny when the ideal burnline was clearly crossing the line at a different value.

In the end, the approach I liked best was to snap the ideal burnline itself to whole point values, so there is no such thing as "completing" a fractional number of points. However, this means the ideal burnline is no longer a straight line, which may confuse some users.
