### PR TITLE
fixes Bug 938346 - attachment flag labeling doesn't ignore obsolete atta...

### DIFF
--- a/bugzilla/api.py
+++ b/bugzilla/api.py
@@ -46,6 +46,7 @@ BZ_ATTACHMENT_FIELDS = [
     'flags',
     'id',
     'is_patch',
+    'is_obsolete',
 ]
 UNWANTED_COMPONENT_FIELDS = [
     'sort_key',

--- a/scrum/models.py
+++ b/scrum/models.py
@@ -757,6 +757,11 @@ class Bug(models.Model):
         # add in the flags from attachments
         for a in self.attachments:
 
+            # if is_obsolete is True, or is_obsolete field doesn't exist,
+            # skip this attachment
+            if a.get('is_obsolete', True):
+                continue
+
             # put the attachment flags into the buckets
             for f in a.get('flags', []):
 
@@ -805,6 +810,11 @@ class Bug(models.Model):
 
         # go through attachment flags too
         for a in self.attachments:
+            # if is_obsolete is True, or is_obsolete field doesn't exist,
+            # skip this attachment
+            if a.get('is_obsolete', True):
+                continue
+
             for f in a.get('flags', []):
                 fs.update(self._bucket_flag_status(f, fs))
 

--- a/scrum/test_data/bugzilla_data.json
+++ b/scrum/test_data/bugzilla_data.json
@@ -136,6 +136,44 @@
           "attacher":{
             "name":"dhuseby"
           },
+          "bug_id":915672,
+          "bug_ref":"https://api-dev.bugzilla.mozilla.org/latest/bug/915672",
+          "content_type":"text/plain",
+          "creation_time":"2013-10-22T22:04:00Z",
+          "description":"Bug_915672.patch",
+          "file_name":"Bug_915672.patch",
+          "flags":[
+            {
+              "id":736507,
+              "name":"review",
+              "setter":{
+                "name":"jgriffin"
+              },
+              "status":"+",
+              "type_id":4
+            },
+            {
+              "id":736694,
+              "name":"feedback",
+              "setter":{
+                "name":"dave.hunt"
+              },
+              "status":"+",
+              "type_id":607
+            }
+          ],
+          "id":820633,
+          "is_obsolete":1,
+          "is_patch":1,
+          "is_private":0,
+          "last_change_time":"2013-11-02T05:55:25Z",
+          "ref":"https://api-dev.bugzilla.mozilla.org/latest/attachment/820633",
+          "size":748781
+        },
+        {
+          "attacher":{
+            "name":"dhuseby"
+          },
           "bug_id":910448,
           "bug_ref":"https://api-dev.bugzilla.mozilla.org/latest/bug/910448",
           "content_type":"text/plain",

--- a/scrum/tests.py
+++ b/scrum/tests.py
@@ -256,6 +256,19 @@ class TestBug(TestCase):
         self.assertEqual('question', b.flags_status.get('ui-review'))
         self.assertEqual('question', b.flags_status.get('feedback'))
 
+    def test_bug_938346(self):
+        """
+        Tests Bug 938346 - attachment flag labeling doesn't ignore obsolete attachments
+        """
+        b = Bug.objects.get(id=778465)
+        ref_ids = []
+        for flag_name, flags in b.bucketed_flags.iteritems():
+            for flag in flags:
+                if 'ref_id' in flag:
+                    ref_ids.append(flag['ref_id'])
+        self.assertSetEqual(set([829407, 830313]),
+                            set(ref_ids))
+        
     def test_get_by_products(self):
         eq_(Bug.objects.by_products(self.p.get_products()).count(), 11)
         b = Bug.objects.get(id=778466)


### PR DESCRIPTION
...chments

this bug is annoying and only took 5 minutes to fix.  here's the before:
![scrumbugz_bug_938346_before](https://f.cloud.github.com/assets/5017470/1542675/30b3b3dc-4d4a-11e3-831a-108436ea05c8.png)
and the after:
![scrumbugz_bug_938346_after](https://f.cloud.github.com/assets/5017470/1542678/37d4c21e-4d4a-11e3-8a90-0f78a003b3a6.png)
